### PR TITLE
Implement ExtractionService core logic

### DIFF
--- a/apps/jd-extractor-svc/src/extraction/extraction.service.spec.ts
+++ b/apps/jd-extractor-svc/src/extraction/extraction.service.spec.ts
@@ -1,0 +1,43 @@
+import { Test } from '@nestjs/testing';
+import { ExtractionService } from './extraction.service';
+import { LlmService, JdDTO } from './llm.service';
+import { NatsClient } from './nats.client';
+
+describe('ExtractionService', () => {
+  let service: ExtractionService;
+  let llmService: LlmService;
+  let natsClient: NatsClient;
+
+  beforeEach(async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [ExtractionService, LlmService, NatsClient],
+    })
+      .overrideProvider(LlmService)
+      .useValue({ extractJd: jest.fn() })
+      .overrideProvider(NatsClient)
+      .useValue({ publish: jest.fn() })
+      .compile();
+
+    service = moduleRef.get(ExtractionService);
+    llmService = moduleRef.get(LlmService);
+    natsClient = moduleRef.get(NatsClient);
+  });
+
+  it('extracts jd text and publishes event', async () => {
+    const jdDto: JdDTO = {
+      requiredSkills: [],
+      experienceYears: { min: 1, max: 3 },
+      educationLevel: 'any',
+      softSkills: [],
+    };
+    (llmService.extractJd as jest.Mock).mockResolvedValue(jdDto);
+
+    await service.handleJobJdSubmitted({ jobId: 'job1', jdText: 'text' });
+
+    expect(llmService.extractJd).toHaveBeenCalledWith('text');
+    expect(natsClient.publish).toHaveBeenCalledWith('analysis.jd.extracted', {
+      jobId: 'job1',
+      jdDto,
+    });
+  });
+});

--- a/apps/jd-extractor-svc/src/extraction/extraction.service.ts
+++ b/apps/jd-extractor-svc/src/extraction/extraction.service.ts
@@ -1,0 +1,28 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { LlmService } from './llm.service';
+import { NatsClient } from './nats.client';
+
+interface JobJdSubmittedPayload {
+  jobId: string;
+  jdText: string;
+}
+
+@Injectable()
+export class ExtractionService {
+  private readonly logger = new Logger(ExtractionService.name);
+
+  constructor(
+    private readonly llmService: LlmService,
+    private readonly natsClient: NatsClient,
+  ) {}
+
+  async handleJobJdSubmitted(payload: JobJdSubmittedPayload): Promise<void> {
+    this.logger.log(`Handling job.jd.submitted for ${payload.jobId}`);
+    const jdDto = await this.llmService.extractJd(payload.jdText);
+    await this.natsClient.publish('analysis.jd.extracted', {
+      jobId: payload.jobId,
+      jdDto,
+    });
+    this.logger.log(`Published analysis.jd.extracted for ${payload.jobId}`);
+  }
+}

--- a/apps/jd-extractor-svc/src/extraction/llm.service.ts
+++ b/apps/jd-extractor-svc/src/extraction/llm.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common';
+
+export interface JdDTO {
+  requiredSkills: { name: string; weight: number }[];
+  experienceYears: { min: number; max: number };
+  educationLevel: 'bachelor' | 'master' | 'phd' | 'any';
+  softSkills: string[];
+}
+
+@Injectable()
+export class LlmService {
+  // This method will be mocked in tests; real implementation is out of scope
+  async extractJd(jdText: string): Promise<JdDTO> {
+    throw new Error('Not implemented');
+  }
+}

--- a/apps/jd-extractor-svc/src/extraction/nats.client.ts
+++ b/apps/jd-extractor-svc/src/extraction/nats.client.ts
@@ -1,0 +1,10 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class NatsClient {
+  // Real implementation would publish to NATS server
+  async publish(subject: string, payload: unknown): Promise<void> {
+    /* istanbul ignore next */
+    return;
+  }
+}


### PR DESCRIPTION
## Summary
Implemented `ExtractionService` with basic JD extraction workflow. Added `LlmService` and `NatsClient` stubs and created accompanying unit tests.

## Testing
- `pnpm exec nx test jd-extractor-svc`

Closes #TASK-JD-EXTRACTOR-IMPL-001

------
https://chatgpt.com/codex/tasks/task_e_687f2d55dbcc832daa676e36d5643f1e