### PR TITLE
Add scoring engine service tests

### DIFF
--- a/apps/scoring-engine-svc/src/nats/nats.client.ts
+++ b/apps/scoring-engine-svc/src/nats/nats.client.ts
@@ -1,0 +1,11 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+@Injectable()
+export class NatsClient {
+  private readonly logger = new Logger(NatsClient.name);
+
+  async emit(subject: string, data: any): Promise<void> {
+    // TODO: Implement NATS event emission
+    throw new Error('NatsClient.emit not implemented');
+  }
+}

--- a/apps/scoring-engine-svc/src/scoring.service.spec.ts
+++ b/apps/scoring-engine-svc/src/scoring.service.spec.ts
@@ -1,0 +1,90 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ScoringEngineService, JdDTO, ScoreDTO } from './scoring.service';
+import { NatsClient } from './nats/nats.client';
+import { ResumeDTO } from '../../../libs/shared-dtos/src/models/resume.dto';
+
+describe('ScoringEngineService', () => {
+  let service: ScoringEngineService;
+  let natsClient: jest.Mocked<NatsClient>;
+
+  const jdPayload: JdDTO = {
+    requiredSkills: [
+      { name: 'typescript', weight: 1 },
+      { name: 'node', weight: 1 },
+    ],
+    experienceYears: { min: 2, max: 5 },
+    educationLevel: 'bachelor',
+    softSkills: ['teamwork'],
+  };
+
+  const resumePayload: ResumeDTO = {
+    contactInfo: { name: 'John Doe', email: 'a@b.com', phone: '1' },
+    skills: ['TypeScript', 'Node'],
+    workExperience: [
+      {
+        company: 'A',
+        position: 'Dev',
+        startDate: '2019-01-01',
+        endDate: '2020-01-01',
+        summary: 'work',
+      },
+    ],
+    education: [
+      { school: 'X', degree: 'bachelor', major: 'CS' },
+    ],
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ScoringEngineService,
+        { provide: NatsClient, useValue: { emit: jest.fn() } },
+      ],
+    }).compile();
+
+    service = module.get(ScoringEngineService);
+    natsClient = module.get(NatsClient);
+  });
+
+  it('invokes score calculation and emits event', async () => {
+    service.handleJdExtractedEvent({ jobId: 'job-123', jdDto: jdPayload });
+
+    const spy = jest.spyOn<any, any>(service as any, '_calculateMatchScore');
+
+    await service.handleResumeParsedEvent({
+      jobId: 'job-123',
+      resumeId: 'res-1',
+      resumeDto: resumePayload,
+    });
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(natsClient.emit).toHaveBeenCalledWith(
+      'analysis.match.scored',
+      expect.objectContaining({
+        jobId: 'job-123',
+        resumeId: 'res-1',
+        scoreDto: expect.any(Object),
+      }),
+    );
+
+    const emitted = (natsClient.emit as jest.Mock).mock.calls[0][1] as {
+      scoreDto: ScoreDTO;
+    };
+    expect(emitted.scoreDto).toEqual(
+      expect.objectContaining({
+        overallScore: expect.any(Number),
+        skillScore: expect.any(Object),
+        experienceScore: expect.any(Object),
+        educationScore: expect.any(Object),
+      }),
+    );
+  });
+
+  describe('_calculateMatchScore', () => {
+    it('calculates weighted score correctly', () => {
+      const result = (service as any)._calculateMatchScore(jdPayload, resumePayload);
+      expect(result.overallScore).toBeGreaterThanOrEqual(0);
+      expect(result.overallScore).toBeLessThanOrEqual(100);
+    });
+  });
+});

--- a/apps/scoring-engine-svc/src/scoring.service.ts
+++ b/apps/scoring-engine-svc/src/scoring.service.ts
@@ -1,0 +1,54 @@
+import { Injectable } from '@nestjs/common';
+import { ResumeDTO } from '../../../libs/shared-dtos/src/models/resume.dto';
+import { NatsClient } from './nats/nats.client';
+
+export interface JdDTO {
+  requiredSkills: { name: string; weight: number }[];
+  experienceYears: { min: number; max: number };
+  educationLevel: 'bachelor' | 'master' | 'phd' | 'any';
+  softSkills: string[];
+}
+
+export interface ScoreComponent {
+  score: number;
+  details: string;
+}
+
+export interface ScoreDTO {
+  overallScore: number;
+  skillScore: ScoreComponent;
+  experienceScore: ScoreComponent;
+  educationScore: ScoreComponent;
+}
+
+@Injectable()
+export class ScoringEngineService {
+  private readonly jdCache = new Map<string, JdDTO>();
+
+  constructor(private readonly natsClient: NatsClient) {}
+
+  handleJdExtractedEvent(event: { jobId: string; jdDto: JdDTO }): void {
+    this.jdCache.set(event.jobId, event.jdDto);
+  }
+
+  async handleResumeParsedEvent(event: {
+    jobId: string;
+    resumeId: string;
+    resumeDto: ResumeDTO;
+  }): Promise<void> {
+    const jdDto = this.jdCache.get(event.jobId);
+    if (!jdDto) {
+      throw new Error('JD not found');
+    }
+    const score = this._calculateMatchScore(jdDto, event.resumeDto);
+    await this.natsClient.emit('analysis.match.scored', {
+      jobId: event.jobId,
+      resumeId: event.resumeId,
+      scoreDto: score,
+    });
+  }
+
+  protected _calculateMatchScore(jdDto: JdDTO, resumeDto: ResumeDTO): ScoreDTO {
+    throw new Error('Not implemented');
+  }
+}


### PR DESCRIPTION
## Summary
- add scoring engine service skeleton and emit stub
- add NATS client stub for scoring service
- create initial failing tests for scoring logic

## Testing
- `pnpm install`
- `npx -y nx test scoring-engine-svc` *(fails: Not implemented)*

------
https://chatgpt.com/codex/tasks/task_e_687f4967108c832dab2dc1eebf5a3b7f