### PR TITLE
Update gitignore for env patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,10 +74,9 @@ web_modules/
 
 # dotenv environment variable files
 .env
-.env.development.local
-.env.test.local
-.env.production.local
+.env.*
 .env.local
+.env.*.local
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache
@@ -172,10 +171,6 @@ out/
 
 # Project graph
 project-graph.json
-
-# Local environment files
-.env.local
-.env.*.local
 
 # OS generated files
 .DS_Store


### PR DESCRIPTION
## Summary
- consolidate environment variable entries in `.gitignore`
- keep `.env` and `.env.*` patterns and remove obsolete duplicates

## Testing
- `npx --yes nx run-many --target=test --all` *(fails: Could not find Nx modules)*
- `npm ci` *(fails: ERESOLVE dependency errors)*

------
https://chatgpt.com/codex/tasks/task_e_6881a23726ec832dbe0b87236575c6bf