### PR TITLE
fix(ci): skip affected e2e when frontend is unchanged

### DIFF
--- a/.github/workflows/ci-affected.yml
+++ b/.github/workflows/ci-affected.yml
@@ -56,9 +56,17 @@ jobs:
       - name: Print affected graph
         run: npx nx show projects --affected --base=origin/main --head=HEAD
       - name: Print affected projects
+        id: affected_projects
         run: |
           echo "Affected projects:"
-          npx nx show projects --affected --base=origin/main --head=HEAD
+          AFFECTED_PROJECTS="$(npx nx show projects --affected --base=origin/main --head=HEAD | tr '\n' ' ')"
+          echo "$AFFECTED_PROJECTS"
+          echo "projects=$AFFECTED_PROJECTS" >> "$GITHUB_OUTPUT"
+          if echo " $AFFECTED_PROJECTS " | grep -qE " (ai-recruitment-frontend|ai-recruitment-frontend-e2e) "; then
+            echo "run_e2e=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_e2e=false" >> "$GITHUB_OUTPUT"
+          fi
           echo ""
           echo "Affected projects with test target:"
           npx nx print-affected --type=test --select=projects --base=origin/main --head=HEAD || echo "No test target projects affected"
@@ -71,7 +79,12 @@ jobs:
       - name: Build affected
         timeout-minutes: 15
         run: npx nx affected -t build --base=origin/main --head=HEAD --parallel=2
+      - name: Build frontend for affected E2E
+        if: steps.affected_projects.outputs.run_e2e == 'true'
+        timeout-minutes: 15
+        run: npx nx build ai-recruitment-frontend --configuration=production
       - name: Manage server lifecycle
+        if: steps.affected_projects.outputs.run_e2e == 'true'
         uses: ./.github/actions/server-lifecycle
         timeout-minutes: 5
         with:
@@ -83,6 +96,7 @@ jobs:
           verify-build-output: 'dist/apps/ai-recruitment-frontend/browser'
           server-log-path: '/tmp/server.log'
       - name: E2E affected
+        if: steps.affected_projects.outputs.run_e2e == 'true'
         timeout-minutes: 18
         # Skip app-gateway-e2e due to complex service dependencies
         # Skip @accessibility tests (pre-existing UI issues)


### PR DESCRIPTION
# Pull Request

## PR Information

**Type**: fix(ci)
**Component**: github-actions
**Related Issue(s)**: Follow-up from Dependabot workflow-only PR CI failures
**Breaking Change**: No

---

## 🎯 Description

### Summary
Skip affected E2E server startup when the affected project set does not include the frontend or frontend E2E project.

### Motivation
Workflow-only PRs can pass lint/test/build affected without producing `dist/apps/ai-recruitment-frontend/browser`; the old ci-affected job still tried to start the frontend server and failed before E2E could be skipped.

### Approach
Capture affected projects once, expose a `run_e2e` output, build the frontend explicitly only when E2E is relevant, and gate server lifecycle/E2E steps on that output.

---

## 🔬 Changes Made

**Modified**:
- `.github/workflows/ci-affected.yml`

**Deleted**:
- None

### Database Changes
- [x] No database changes

### API Changes
- [x] No API changes

---

## 🧪 Testing Evidence

### Test Coverage

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [x] Workflow validation required by PR CI

**Test Results**:
```
npx prettier --check .github/workflows/ci-affected.yml
```

### Testing Checklist
- [ ] All tests passing locally
- [ ] Linter passes
- [ ] Type checking passes
- [ ] Build successful

---

## 📊 Quality Checks

### Code Quality
- [x] Workflow condition is scoped to affected projects
- [x] Formatting checked
- [ ] GitHub checks are green

### Security
- [x] No secrets changed
- [x] No permissions broadened

---

## 📋 PR Checklist

- [ ] All tests passing locally
- [ ] Linter passes
- [ ] Type checking passes
- [ ] Build successful
- [ ] GitHub checks are green
- [x] Branch is up to date with main
