### PR TITLE
fix(ci): silence husky prepare in release

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lint:fix": "npx nx run-many -t lint --all --parallel=3 --fix",
     "clean": "npx nx reset && rm -rf node_modules/.cache dist",
     "start:prod": "NODE_ENV=production node dist/apps/app-gateway/main.cjs",
-    "prepare": "husky install",
+    "prepare": "node scripts/husky-prepare.mjs",
     "postinstall": "echo 'Skipping build in postinstall'",
     "format": "prettier --write \"{apps,libs}/**/*.{ts,html,scss,js,json,md}\"",
     "test": "jest --config jest.config.mjs --passWithNoTests",

--- a/scripts/husky-prepare.mjs
+++ b/scripts/husky-prepare.mjs
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+
+const shouldSkip =
+  process.env.HUSKY === '0' ||
+  process.env.SKIP_PRE_PUSH === 'true' ||
+  process.env.CI === 'true';
+
+if (shouldSkip) {
+  process.exit(0);
+}
+
+const result = spawnSync('husky', ['install'], {
+  shell: process.platform === 'win32',
+  stdio: 'inherit',
+});
+
+if (result.error) {
+  console.error(result.error.message);
+  process.exit(1);
+}
+
+process.exit(result.status ?? 0);


### PR DESCRIPTION
**Type**: fix(ci)
**Breaking Change**: No

## 🎯 Description
Semantic Release fails during `@semantic-release/npm` prepare because the root `prepare` lifecycle currently runs `husky install`. When `HUSKY=0`, Husky writes `HUSKY=0 skip install` to stdout, and npm pack output is parsed as a corrupted tarball filename.

This PR makes the prepare lifecycle quiet in CI/release environments while preserving local hook installation for developer installs.

## 🔬 Changes Made
- Replaced `prepare: husky install` with `prepare: node scripts/husky-prepare.mjs`.
- Added `scripts/husky-prepare.mjs` to silently exit when `HUSKY=0`, `SKIP_PRE_PUSH=true`, or `CI=true`.
- Kept local Husky installation behavior by delegating to `husky install` outside skipped environments.

## 🧪 Testing Evidence
### Test Coverage
- `HUSKY=0 npm pack --dry-run` final output is `ai-recruitment-clerk-1.0.1.tgz`.
- `npm run audit` passed with `found 0 vulnerabilities`.

### Code Quality
- `git diff --check` passed.
- Change is limited to release lifecycle behavior and does not affect runtime code.

## 📋 PR Checklist
- [ ] All tests passing locally
- [ ] Linter passes
- [ ] Type checking passes
- [ ] Build successful
- [x] No breaking changes
- [x] Release failure root cause verified from GitHub Actions logs