### PR TITLE
fix(ci): disable release issue success automation

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -85,11 +85,11 @@
             "label": "Distribution Package"
           }
         ],
-        "successComment": "🎉 This ${issue.pull_request ? 'PR is included' : 'issue has been resolved'} in version ${nextRelease.version} 🎉\n\nThe release is available on:\n- [GitHub Releases](${releases[0].url})\n\nYour **${issue.pull_request ? 'pull request' : 'issue'}** has been automatically closed.",
+        "successComment": false,
         "failComment": false,
         "failTitle": false,
         "labels": ["released"],
-        "releasedLabels": ["released<%= nextRelease.channel ? `-${nextRelease.channel}` : '' %>@<%= nextRelease.version %>"]
+        "releasedLabels": false
       }
     ]
   ],


### PR DESCRIPTION
**Type**: fix(ci)
**Breaking Change**: No

## 🎯 Description
Semantic Release now creates the release commit, tag, GitHub release, and tarball successfully, but the workflow still fails in the `@semantic-release/github` success step when historical release notes contain references to non-existent issues such as `#15965`.

This PR keeps GitHub Release publication enabled and disables only the issue/PR success automation that comments on and labels resolved historical references.

## 🔬 Changes Made
- Set `@semantic-release/github` `successComment` to `false`.
- Set `releasedLabels` to `false`.
- Left release assets, fail issue suppression, and GitHub Release publication intact.

## 🧪 Testing Evidence
### Test Coverage
- Verified `.releaserc.json` parses successfully with Node.
- `npm run audit` passed with `found 0 vulnerabilities`.

### Code Quality
- `git diff --check` passed.
- Change is limited to Semantic Release configuration.

## 📋 PR Checklist
- [ ] All tests passing locally
- [ ] Linter passes
- [ ] Type checking passes
- [ ] Build successful
- [x] No breaking changes
- [x] Release failure root cause verified from GitHub Actions logs