### PR TITLE
fix(ci): start cd-local smoke server

### DIFF
--- a/.github/workflows/cd-local.yml
+++ b/.github/workflows/cd-local.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
 
-
 jobs:
   pre-release-deploy:
     runs-on: ubuntu-latest
@@ -14,7 +13,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: '20'
+          node-version: '22.22.0'
       - name: Cache npm
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
@@ -42,7 +41,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: '20'
+          node-version: '22.22.0'
       - name: Cache npm
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
@@ -59,6 +58,27 @@ jobs:
             ${{ runner.os }}-playwright-
       - name: Install deps
         run: npm ci
+      - name: Build frontend for E2E smoke
+        run: npx nx build ai-recruitment-frontend --configuration=production
+      - name: Start static server for E2E smoke
+        run: |
+          npx nx run ai-recruitment-frontend:serve-static --port 4200 > /tmp/server.log 2>&1 &
+          SERVER_PID=$!
+          echo "SERVER_PID=$SERVER_PID" >> "$GITHUB_ENV"
+          echo "Waiting for server to be ready..."
+          for i in {1..12}; do
+            if curl -s -f http://localhost:4200 > /dev/null 2>&1; then
+              echo "Server is ready after ${i}s!"
+              break
+            fi
+            echo "Waiting... ($i/12)"
+            sleep 5
+          done
+          if ! curl -s -f http://localhost:4200 > /dev/null 2>&1; then
+            echo "Server failed to start. Log output:"
+            cat /tmp/server.log
+            exit 1
+          fi
       - name: Install Playwright browsers
         run: npx playwright install --with-deps || npx playwright install
       - name: Run E2E Smoke
@@ -66,6 +86,12 @@ jobs:
         env:
           CI: true
           E2E_SKIP_WEBSERVER: true
+      - name: Stop static server
+        if: always()
+        run: |
+          if [ -n "${SERVER_PID:-}" ]; then
+            kill "$SERVER_PID" || true
+          fi
       - name: Upload Playwright report
         if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0


### PR DESCRIPTION
**Type**: fix(ci)
**Breaking Change**: No

## 🎯 Description
The latest main `cd-local` workflow fails in `post-deploy-smoke` because it sets `E2E_SKIP_WEBSERVER=true` but never starts an external frontend server at `http://localhost:4200`.

This PR aligns `cd-local` with the already-passing CI E2E pattern by building the frontend, serving it statically, and cleaning up the server process after the smoke run.

## 🔬 Changes Made
- Updated cd-local Node setup from Node 20 to Node 22.22.0.
- Added production frontend build before post-deploy E2E smoke.
- Added static server startup and readiness check on port 4200.
- Added always-run static server cleanup.

## 🧪 Testing Evidence
### Test Coverage
- `npm run audit` passed with `found 0 vulnerabilities`.
- Fix mirrors the existing passing static-server setup in the main CI workflow.

### Code Quality
- `git diff --check` passed.
- `npx prettier --check .github/workflows/cd-local.yml` passed.

## 📋 PR Checklist
- [ ] All tests passing locally
- [ ] Linter passes
- [ ] Type checking passes
- [ ] Build successful
- [x] No breaking changes
- [x] cd-local failure root cause verified from GitHub Actions logs